### PR TITLE
Allow new features with tox v1.6

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,12 @@
 [tox]
-envlist = py27,pep8
+envlist = py26,py27,pep8
+minversion = 1.6
+skipsdist = True
 
 [testenv]
 setenv = VIRTUAL_ENV={envdir}
+usedevelop = True
+install_command = pip install {opts} {packages}
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
 commands =


### PR DESCRIPTION
Reasons:
- tox update v1.6
  Changes:
- tox 1.6 allows us to skip the sdist step, which is slow.
- It also allows us to override the install line. In this case, it's
  important as it allows us to stop getting pre-release software we
  weren't asking for.

Original patch by Monty Taylor, talked about here:
http://lists.openstack.org/pipermail/openstack-dev/2013-September/015495.html
